### PR TITLE
fix(bing): Allow to pass custom systemMessage to Bing AI when using server mode

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -106,6 +106,7 @@ server.post('/conversation', async (request, reply) => {
             invocationId: body.invocationId,
             shouldGenerateTitle: settings.apiOptions?.generateTitles || false, // only used for ChatGPTClient
             toneStyle: body.toneStyle,
+            systemMessage: body.systemMessage,
             clientOptions,
             onProgress,
             abortController,


### PR DESCRIPTION
Allow to pass custom systemMessage to Bing AI when using server mode